### PR TITLE
Add observer to s3 path

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,6 +86,8 @@ A longer sentence, about how exactly to use this program`,
 			cfg.TestFrequencySeconds = testSec
 			logrus.WithField("seconds", cfg.TestFrequencySeconds).Info("Running tests every x seconds")
 
+			// TODO need to clean the observer id to conform to S3 or reject if doesn't conform. also no /
+
 			// TODO make this dynamic and less hardcoded
 			if cfg.RuntimeCloudProviderMetadata.BunnyPodId != "" {
 				logrus.Info("Cloud provider: Bunny Magic Container Runtime detected")

--- a/internal/service/hachyboop.go
+++ b/internal/service/hachyboop.go
@@ -285,8 +285,8 @@ func (hb *Hachyboop) writeObservationsToLocalFile(observations []*HachyboopDnsOb
 
 func (hb *Hachyboop) writeObservationsToS3(observations []*HachyboopDnsObservation) {
 	logrus.Debug("Preparing S3 file writer")
-	path := filepath.Join(hb.Options.S3Output.Path, time.Now().UTC().Format("2006-01-02T15.04.05.parquet"))
-	logrus.WithField("s3path", "s3://"+filepath.Join(hb.Options.S3Output.Bucket, path, hb.Options.ObserverId)).Debug("S3 output path prepared")
+	path := filepath.Join(hb.Options.S3Output.Path, hb.Options.ObserverId, time.Now().UTC().Format("2006-01-02T15.04.05.parquet"))
+	logrus.WithField("s3path", "s3://"+filepath.Join(hb.Options.S3Output.Bucket, path)).Debug("S3 output path prepared")
 
 	awsCfg := &aws.Config{
 		Region:      aws.String("US"),

--- a/internal/service/hachyboop.go
+++ b/internal/service/hachyboop.go
@@ -258,7 +258,7 @@ func (hb *Hachyboop) queryResolvers(resolvers []*dns.TargetedResolver) {
 
 func (hb *Hachyboop) writeObservationsToLocalFile(observations []*HachyboopDnsObservation) {
 	logrus.Debug("Prepping local file writer")
-	path := filepath.Join(hb.Options.FileOutput.Path, hb.Options.ObserverId, time.Now().UTC().Format("2006-01-02T15.04.05.parquet"))
+	path := filepath.Join(hb.Options.FileOutput.Path, time.Now().UTC().Format("2006-01-02T15.04.05.parquet"))
 	logrus.WithField("filepath", path).Debug("Parquet local path prepared")
 
 	fw, err := local.NewLocalFileWriter(path)
@@ -286,7 +286,7 @@ func (hb *Hachyboop) writeObservationsToLocalFile(observations []*HachyboopDnsOb
 func (hb *Hachyboop) writeObservationsToS3(observations []*HachyboopDnsObservation) {
 	logrus.Debug("Preparing S3 file writer")
 	path := filepath.Join(hb.Options.S3Output.Path, time.Now().UTC().Format("2006-01-02T15.04.05.parquet"))
-	logrus.WithField("s3path", "s3://"+filepath.Join(hb.Options.S3Output.Bucket, path)).Debug("S3 output path prepared")
+	logrus.WithField("s3path", "s3://"+filepath.Join(hb.Options.S3Output.Bucket, path, hb.Options.ObserverId)).Debug("S3 output path prepared")
 
 	awsCfg := &aws.Config{
 		Region:      aws.String("US"),

--- a/internal/service/hachyboop.go
+++ b/internal/service/hachyboop.go
@@ -258,7 +258,7 @@ func (hb *Hachyboop) queryResolvers(resolvers []*dns.TargetedResolver) {
 
 func (hb *Hachyboop) writeObservationsToLocalFile(observations []*HachyboopDnsObservation) {
 	logrus.Debug("Prepping local file writer")
-	path := filepath.Join(hb.Options.FileOutput.Path, time.Now().UTC().Format("2006-01-02T15.04.05.parquet"))
+	path := filepath.Join(hb.Options.FileOutput.Path, hb.Options.ObserverId, time.Now().UTC().Format("2006-01-02T15.04.05.parquet"))
 	logrus.WithField("filepath", path).Debug("Parquet local path prepared")
 
 	fw, err := local.NewLocalFileWriter(path)


### PR DESCRIPTION
Adds the observer to the S3 path automatically so that it can be a bit more dynamic when running in envs like Bunny MC.